### PR TITLE
Adapt to new pip command: download

### DIFF
--- a/pypiuploader/download.py
+++ b/pypiuploader/download.py
@@ -10,7 +10,7 @@ class PackageDownloader(object):
 
     """Downloads source distributions from PyPI to a directory.
 
-    Runs ``pip install`` command, e.g.::
+    Runs ``pip download`` command, e.g.::
 
         >>> downloader = PackageDownloader('~/.packages')
         >>> downloader.download(['mock', 'requests==1.2.1'])
@@ -19,7 +19,7 @@ class PackageDownloader(object):
 
     .. code-block:: bash
 
-        $ pip install -d ~/.packages mock requests==1.2.1
+        $ pip download -d ~/.packages mock requests==1.2.1
 
     And this:
 
@@ -30,7 +30,7 @@ class PackageDownloader(object):
 
     .. code-block:: bash
 
-        $ pip install -d ~/.packages -r requirements.txt
+        $ pip download -d ~/.packages -r requirements.txt
 
     :param download_path:
         Optional path to directory where the packages should be downloaded,
@@ -51,7 +51,7 @@ class PackageDownloader(object):
             requirements=None,
             requirements_file=None,
             no_use_wheel=False):
-        """Download the packages using ``pip install`` command.
+        """Download the packages using ``pip download`` command.
 
         Either ``requirements`` or ``requirements_file`` must be given,
         otherwise raise :exc:`ValueError`.
@@ -63,8 +63,8 @@ class PackageDownloader(object):
         :param requirements_file:
             Optional path to a requirements file.
         :param no_use_wheel:
-            Do not find and prefer wheel archives, default to ``False``.
-            Corresponds to ``--no-use-wheel`` option from ``pip install``.
+            Do not use wheel archives, default to ``False``.
+            Corresponds to ``--no-binary :all:`` option from ``pip download``.
 
         """
         self._make_download_dir()
@@ -78,12 +78,12 @@ class PackageDownloader(object):
             requirements_file=None,
             no_use_wheel=False):
         args = [
-            'install',
+            'download',
             '-d',
             self.download_path,
         ]
         if no_use_wheel:
-            args.append('--no-use-wheel')
+            args.extend(['--no-binary', ':all:'])
         if requirements is not None:
             args.extend(requirements)
         elif requirements_file is not None:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ class PyTest(TestCommand):
 
 install_requires = [
     'requests',
+    'pip>=8',
 ]
 tests_require = [
     'mock',

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -59,12 +59,13 @@ class TestPackageDownloader(object):
     def test_build_args_with_requirements(self):
         downloader = download.PackageDownloader('/foo/bar')
         args = downloader._build_args(requirements=['requests==1.2.1', 'mock'])
-        assert args == ['install', '-d', '/foo/bar', 'requests==1.2.1', 'mock']
+        assert args == ['download', '-d', '/foo/bar',
+                        'requests==1.2.1', 'mock']
 
     def test_build_args_with_requirements_file(self):
         downloader = download.PackageDownloader('/foo/bar')
         args = downloader._build_args(requirements_file='requirements.txt')
-        assert args == ['install', '-d', '/foo/bar', '-r', 'requirements.txt']
+        assert args == ['download', '-d', '/foo/bar', '-r', 'requirements.txt']
 
     def test_build_args_without_arguments(self):
         downloader = download.PackageDownloader('/foo/bar')
@@ -77,9 +78,9 @@ class TestPackageDownloader(object):
             requirements_file='requirements.txt',
             no_use_wheel=True)
         assert args == [
-            'install',
+            'download',
             '-d', '/foo/bar',
-            '--no-use-wheel',
+            '--no-binary', ':all:',
             '-r', 'requirements.txt',
         ]
 
@@ -106,7 +107,7 @@ class TestPackageDownloader(object):
         downloaded = downloader.download(requirements=['mock'])
 
         assert sorted(list(downloaded)) == ['mock-1.0.1.tar.gz']
-        expected_call = mock.call(['install', '-d', download_path, 'mock'])
+        expected_call = mock.call(['download', '-d', download_path, 'mock'])
         assert pip_main_mock.call_args == expected_call
 
     @mock.patch('pip.main', autospec=True)
@@ -117,7 +118,7 @@ class TestPackageDownloader(object):
         downloader.download(requirements_file='requirements.txt')
 
         expected_call = mock.call(
-            ['install', '-d', download_path, '-r', 'requirements.txt'])
+            ['download', '-d', download_path, '-r', 'requirements.txt'])
         assert pip_main_mock.call_args == expected_call
 
     @mock.patch('pip.main', autospec=True)
@@ -130,9 +131,9 @@ class TestPackageDownloader(object):
             no_use_wheel=True)
 
         expected_call = mock.call([
-            'install',
+            'download',
             '-d', download_path,
-            '--no-use-wheel',
+            '--no-binary', ':all:',
             '-r', 'requirements.txt',
         ])
         assert pip_main_mock.call_args == expected_call


### PR DESCRIPTION
pip will deprecate the `install -d <dir>` in next version.